### PR TITLE
Simplify pot expression (upstream a downstream commit from Yuni)

### DIFF
--- a/tilecalc.py
+++ b/tilecalc.py
@@ -75,8 +75,8 @@ for wsize, w, h, levels, xoffsets in tests:
 
         # Round up to POT if tile size is <64
         if t < 64:
-            lod_w = pot(aup(lod_w, t))
-            lod_h = pot(aup(lod_h, t))
+            lod_w = pot(lod_w)
+            lod_h = pot(lod_h)
 
         if lt != t:
             s += f" \x1b[35mt={t:<2d}\x1b[m "


### PR DESCRIPTION
Since t = potl(min(64, lod_w, lod_h)), t is a power-of-two <= lod_w.
That implies that pot(aup(lod_w, t)) = pot(lod_w), so we can simplify
out the aup. (I wrote out the full proof in my notebook but it was
pretty messy and long, so not reproducing here.)